### PR TITLE
Fix bad behavior when --cppopts unspecified

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -102,7 +102,11 @@ parseFile :: FilePath -> C2HscOptions -> IO ()
 parseFile gccPath opts =
   for_ (files opts) $ \fileName -> do
     result <- runPreprocessor (newGCC gccPath)
-                              (rawCppArgs [cppopts opts] fileName)
+                              (rawCppArgs
+                                (if null (cppopts opts)
+                                  then []
+                                  else [cppopts opts])
+                                fileName)
     case result of
       Left err     -> error $ "Failed to run cpp: " ++ show err
       Right stream -> do


### PR DESCRIPTION
Because I wasn't specifying --cppopts, 'cppopts opts' was "", so the first value given to language-c's runPreprocessor was [""]. This caused language-c to run gcc with ["-o","/tmp/xxx.i","-E","xxx.h",""](note the final), which caused gcc to die with "error: : No such file or directory".
