### PR TITLE
Allow the file prefix argument to be specified multiple times

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -7,7 +7,7 @@ import Data.List as L
 import Prelude hiding (concat, sequence, mapM, mapM_, foldr)
 import System.Console.CmdArgs
 import System.Environment
-
+
 version :: String
 version = "0.7.0"
 
@@ -37,7 +37,7 @@ c2hscOptions = C2HscOptions
     summary c2hscSummary &=
     program "c2hsc" &=
     help "Create an .hsc Bindings-DSL file from a C API header file"
-
+
 ------------------------------ IMPURE FUNCTIONS ------------------------------
 
 -- Parsing of C headers begins with finding gcc so we can run the


### PR DESCRIPTION
This pull request allows the file prefix flag (-f) to be specified multiple times so declarations in multiple different files are output. In my case, I have a header split across multiple files that should all exist in one module.

I hope you don't mind; I also removed some superfluous line feed characters I saw.